### PR TITLE
Touch relative to control (Windows Phone)

### DIFF
--- a/NControl/NControl.WP80/NControlViewRenderer.cs
+++ b/NControl/NControl.WP80/NControlViewRenderer.cs
@@ -195,7 +195,7 @@ namespace NControl.WP80
                     if (!ourRect.Contains(mainTouchPoint.Position.X, mainTouchPoint.Position.Y))
                         return;
 
-                    var touches = e.GetTouchPoints(page).Select(t => new NGraphics.Point(t.Position.X, t.Position.Y));
+                    var touches = e.GetTouchPoints(this).Select(t => new NGraphics.Point(t.Position.X, t.Position.Y));
 
                     if (mainTouchPoint.Action == TouchAction.Move)
                     {

--- a/NControl/NControl.WP81/NControlViewRenderer.cs
+++ b/NControl/NControl.WP81/NControlViewRenderer.cs
@@ -196,7 +196,7 @@ namespace NControl.WP81
                     if (!ourRect.Contains(mainTouchPoint.Position.X, mainTouchPoint.Position.Y))
                         return;
 
-                    var touches = e.GetTouchPoints(page).Select(t => new NGraphics.Point(t.Position.X, t.Position.Y));
+                    var touches = e.GetTouchPoints(this).Select(t => new NGraphics.Point(t.Position.X, t.Position.Y));
 
                     if (mainTouchPoint.Action == TouchAction.Move)
                     {


### PR DESCRIPTION
The touch points passed to the touch events were not relative to the control, but to the page. However, since the touch points are relative to the control on other plattforms (tested on Android), so should they on WP.
