### PR TITLE
Fixed Pen.Width handling for WP Plattforms

### DIFF
--- a/NControl/NControl.WP80/PhoneSilverlightPlatform.cs
+++ b/NControl/NControl.WP80/PhoneSilverlightPlatform.cs
@@ -347,8 +347,9 @@ namespace NControl.WP80
         public void DrawRectangle(Rect frame, Pen pen = null, NGraphics.Brush brush = null)
         {
             var rectangleEl = new System.Windows.Shapes.Rectangle();
-            rectangleEl.Width = frame.Width;
-            rectangleEl.Height = frame.Height;
+            var offset = pen != null ? pen.Width : 0.0;
+            rectangleEl.Width = frame.Width + offset;
+            rectangleEl.Height = frame.Height + offset;
 
             if (brush != null)
                 rectangleEl.Fill = GetBrush(brush);
@@ -360,8 +361,8 @@ namespace NControl.WP80
             }
 
             _canvas.Children.Add(rectangleEl);
-            Canvas.SetLeft(rectangleEl, frame.X);
-            Canvas.SetTop(rectangleEl, frame.Y);
+            Canvas.SetLeft(rectangleEl, frame.X - offset / 2.0);
+            Canvas.SetTop(rectangleEl, frame.Y - offset / 2.0);
         }
 
         /// <summary>
@@ -373,8 +374,10 @@ namespace NControl.WP80
         public void DrawEllipse(Rect frame, Pen pen = null, NGraphics.Brush brush = null)
         {
             var ellipseEl = new System.Windows.Shapes.Ellipse();
-            ellipseEl.Width = frame.Width;
-            ellipseEl.Height = frame.Height;
+            var offset = pen != null ? pen.Width : 0.0;
+
+            ellipseEl.Width = frame.Width + offset;
+            ellipseEl.Height = frame.Height + offset;
 
             if (brush != null)
                 ellipseEl.Fill = GetBrush(brush);
@@ -386,8 +389,8 @@ namespace NControl.WP80
             }
 
             _canvas.Children.Add(ellipseEl);
-            Canvas.SetLeft(ellipseEl, frame.X);
-            Canvas.SetTop(ellipseEl, frame.Y);
+            Canvas.SetLeft(ellipseEl, frame.X - offset / 2.0);
+            Canvas.SetTop(ellipseEl, frame.Y - offset / 2.0);
         }
 
         /// <summary>

--- a/NControl/NControl.WP81/PhoneSilverlightPlatform.cs
+++ b/NControl/NControl.WP81/PhoneSilverlightPlatform.cs
@@ -347,8 +347,9 @@ namespace NControl.WP81
         public void DrawRectangle(Rect frame, Pen pen = null, NGraphics.Brush brush = null)
         {
             var rectangleEl = new System.Windows.Shapes.Rectangle();
-            rectangleEl.Width = frame.Width;
-            rectangleEl.Height = frame.Height;
+            var offset = pen != null ? pen.Width : 0.0;
+            rectangleEl.Width = frame.Width + offset;
+            rectangleEl.Height = frame.Height + offset;
 
             if (brush != null)            
                 rectangleEl.Fill = GetBrush(brush);
@@ -360,8 +361,8 @@ namespace NControl.WP81
             }
 
             _canvas.Children.Add(rectangleEl);
-            Canvas.SetLeft(rectangleEl, frame.X);
-            Canvas.SetTop(rectangleEl, frame.Y);            
+            Canvas.SetLeft(rectangleEl, frame.X - offset / 2.0);
+            Canvas.SetTop(rectangleEl, frame.Y - offset / 2.0);           
         }
             
         /// <summary>
@@ -373,8 +374,9 @@ namespace NControl.WP81
         public void DrawEllipse(Rect frame, Pen pen = null, NGraphics.Brush brush = null)
         {
             var ellipseEl = new System.Windows.Shapes.Ellipse();
-            ellipseEl.Width = frame.Width;
-            ellipseEl.Height = frame.Height;
+            var offset = pen != null ? pen.Width : 0.0;
+            ellipseEl.Width = frame.Width + offset;
+            ellipseEl.Height = frame.Height + offset;
 
             if (brush != null)
                 ellipseEl.Fill = GetBrush(brush);
@@ -386,8 +388,8 @@ namespace NControl.WP81
             }
 
             _canvas.Children.Add(ellipseEl);
-            Canvas.SetLeft(ellipseEl, frame.X);
-            Canvas.SetTop(ellipseEl, frame.Y);    
+            Canvas.SetLeft(ellipseEl, frame.X - offset / 2.0);
+            Canvas.SetTop(ellipseEl, frame.Y - offset / 2.0);    
         }
             
         /// <summary>


### PR DESCRIPTION
I have noticed that on Windows Phone, the pen width is handled in such a way that the complete ellipse fits into the specified Rect. This is different from the plattforms in NGraphics (I tested Android and iOS), in that the drawn ellipse on these plattforms will be larger than the Rect.

Although I like the way it is handled on WP better (because I can always be sure that my ellipse fits into my Rect), I think it should be changed to behave like the other plattforms for the sake of simplicity.

Feel free to use this PR for discussion on this topic - maybe it should instead be reported as an issue to [NGraphics](https://github.com/praeclarum/NGraphics) (i.e. treat the implementation in NControl as the correct one and it should be fixed for Android and iOS)?
