### PR TITLE
Fix for assembly link issue #21

### DIFF
--- a/NControl/NControl.Droid/NControlViewRenderer.cs
+++ b/NControl/NControl.Droid/NControlViewRenderer.cs
@@ -41,12 +41,16 @@ namespace NControl.Droid
     /// <summary>
     /// NControlView renderer.
     /// </summary>
+    [Preserve(AllMembers = true)]
     public class NControlViewRenderer : VisualElementRenderer<NControlView>
     {
         /// <summary>
         /// Used for registration with dependency service
         /// </summary>
-        public static void Init() { }
+        public static void Init ()
+        {
+            var temp = DateTime.Now;
+        }
 
         /// <summary>
         /// Raises the element changed event.

--- a/NControl/NControl.iOS/NControlViewRenderer.cs
+++ b/NControl/NControl.iOS/NControlViewRenderer.cs
@@ -33,6 +33,8 @@ using NGraphics;
 using UIKit;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.iOS;
+using Foundation;
+using System;
 
 [assembly: ExportRenderer(typeof(NControlView), typeof(NControlViewRenderer))]
 namespace NControl.iOS
@@ -40,6 +42,7 @@ namespace NControl.iOS
 	/// <summary>
 	/// NControlView renderer.
 	/// </summary>
+    [Preserve(AllMembers = true)]
     public class NControlViewRenderer: VisualElementRenderer<NControlView>
 	{
         /// <summary>
@@ -50,7 +53,10 @@ namespace NControl.iOS
 		/// <summary>
 		/// Used for registration with dependency service
 		/// </summary>
-		public new static void Init() { }
+		public static void Init()
+        {
+            var temp = DateTime.Now;
+        }
 
         /// <summary>
         /// Raises the element changed event.


### PR DESCRIPTION
Fixes the issue causing release builds to not work properly when using the default build option `Link SDK assemblies only`.
