### PR TITLE
move custom drawing after (over) children on Android

### DIFF
--- a/NControl/NControl.Droid/NControlViewRenderer.cs
+++ b/NControl/NControl.Droid/NControlViewRenderer.cs
@@ -120,15 +120,10 @@ namespace NControl.Droid
             // Fill background 
             ncanvas.FillRectangle(rect, new NGraphics.Color(Element.BackgroundColor.R, Element.BackgroundColor.G, Element.BackgroundColor.B, Element.BackgroundColor.A));
 
-            // Custom drawing
-            Element.Draw(ncanvas, rect);
-
-            // Redraw children - since we might have a composite control containing both children 
-            // and custom drawing code, we want children to be drawn last. The reason for this double-
-            // drawing is that the base.Draw(canvas) call will handle background which is needed before
-            // doing NGraphics drawing - but unfortunately it also draws children - which then will 
-            // be drawn below NGraphics drawings.
             base.Draw(canvas);
+
+            // Custom drawing over children
+            Element.Draw(ncanvas, rect);
         }
 
         #endregion


### PR DESCRIPTION
In my opinion, being able do draw over children is much more useful. It also seems to be consistent with the iOS renderer (although I can't test it).
An alternative would be to have 2 methods `Draw()` and `DrawOver()` like the[RecyclerView.ItemDecoration](https://developer.android.com/reference/android/support/v7/widget/RecyclerView.ItemDecoration.html)
