### PR TITLE
Add the generic variant for NControlViewRenderer

### DIFF
--- a/NControl.Win/NControlViewRendererBase.cs
+++ b/NControl.Win/NControlViewRendererBase.cs
@@ -38,10 +38,13 @@ using Xamarin.Forms.Platform.WinPhone;
 
 namespace NControl.Win
 {
+    public abstract class NControlViewRendererBase : NControlViewRendererBase<NControlView> { }
+
     /// <summary>
     /// NControlView renderer.
     /// </summary>
-    public abstract class NControlViewRendererBase : ViewRenderer<NControlView, Border>
+    public abstract class NControlViewRendererBase<TNControlView> : ViewRenderer<TNControlView, Border>
+        where TNControlView : NControlView
     {
         /// <summary>
         /// Used for registration with dependency service
@@ -70,7 +73,7 @@ namespace NControl.Win
         /// Raises the element changed event.
         /// </summary>
         /// <param name="e">E.</param>
-        protected override void OnElementChanged(ElementChangedEventArgs<NControlView> e)
+        protected override void OnElementChanged(ElementChangedEventArgs<TNControlView> e)
         {
             base.OnElementChanged(e);
 
@@ -262,7 +265,7 @@ namespace NControl.Win
                 }
 
                 // Are we interested?
-                var renderer = uiElement as NControlViewRendererBase;
+                var renderer = uiElement as NControlViewRendererBase<TNControlView>;
                 if (renderer == null)
                     continue;
 

--- a/NControl/NControl.Droid/NControlViewRenderer.cs
+++ b/NControl/NControl.Droid/NControlViewRenderer.cs
@@ -38,11 +38,14 @@ using Xamarin.Forms.Platform.Android;
 [assembly: ExportRenderer(typeof(NControlView), typeof(NControlViewRenderer))]
 namespace NControl.Droid
 {
+    public class NControlViewRenderer : NControlViewRenderer<NControlView> { }
+
     /// <summary>
     /// NControlView renderer.
     /// </summary>
     [Preserve(AllMembers = true)]
-    public class NControlViewRenderer : VisualElementRenderer<NControlView>
+    public class NControlViewRenderer<TNControlView> : VisualElementRenderer<TNControlView>
+        where TNControlView : NControlView
     {
         /// <summary>
         /// Used for registration with dependency service
@@ -56,7 +59,7 @@ namespace NControl.Droid
         /// Raises the element changed event.
         /// </summary>
         /// <param name="e">E.</param>
-        protected override void OnElementChanged(ElementChangedEventArgs<NControlView> e)
+        protected override void OnElementChanged(ElementChangedEventArgs<TNControlView> e)
         {
             base.OnElementChanged(e);
 

--- a/NControl/NControl.WP80/NControlViewRenderer.cs
+++ b/NControl/NControl.WP80/NControlViewRenderer.cs
@@ -48,10 +48,13 @@ using NGraphics;
 [assembly: ExportRenderer(typeof(NControlView), typeof(NControlViewRenderer))]
 namespace NControl.WP80
 {
+    public class NControlViewRenderer : NControlViewRenderer<NControlView> { }
+
     /// <summary>
     /// NControlView renderer.
     /// </summary>
-    public class NControlViewRenderer : NControlViewRendererBase
+    public class NControlViewRenderer<TNControlView> : NControlViewRendererBase<TNControlView>
+        where TNControlView : NControlView
     {
         /// <summary>
         /// Used for registration with dependency service

--- a/NControl/NControl.WP81/NControlViewRenderer.cs
+++ b/NControl/NControl.WP81/NControlViewRenderer.cs
@@ -10,10 +10,13 @@ using Xamarin.Forms;
 [assembly: ExportRenderer(typeof(NControlView), typeof(NControlViewRenderer))]
 namespace NControl.WP81
 {
+    public class NControlViewRenderer : NControlViewRenderer<NControlView> { }
+
     /// <summary>
     /// NControlView renderer.
     /// </summary>
-    public class NControlViewRenderer: NControlViewRendererBase
+    public class NControlViewRenderer<TNControlView>: NControlViewRendererBase<TNControlView>
+        where TNControlView : NControlView
     {
         /// <summary>
         /// Used for registration with dependency service

--- a/NControl/NControl.iOS/NControlViewRenderer.cs
+++ b/NControl/NControl.iOS/NControlViewRenderer.cs
@@ -39,11 +39,14 @@ using System;
 [assembly: ExportRenderer(typeof(NControlView), typeof(NControlViewRenderer))]
 namespace NControl.iOS
 {
-	/// <summary>
-	/// NControlView renderer.
-	/// </summary>
+    public class NControlViewRenderer : NControlViewRenderer<NControlView> { }
+
+    /// <summary>
+    /// NControlView renderer.
+    /// </summary>
     [Preserve(AllMembers = true)]
-    public class NControlViewRenderer: VisualElementRenderer<NControlView>
+    public class NControlViewRenderer<TNControlView> : VisualElementRenderer<TNControlView>
+        where TNControlView : NControlView
 	{
         /// <summary>
         /// The gesture recognizer.
@@ -62,7 +65,7 @@ namespace NControl.iOS
         /// Raises the element changed event.
         /// </summary>
         /// <param name="e">E.</param>
-        protected override void OnElementChanged(ElementChangedEventArgs<NControlView> e)
+        protected override void OnElementChanged(ElementChangedEventArgs<TNControlView> e)
         {
             base.OnElementChanged(e);
 


### PR DESCRIPTION
This will ease re-use for controls that inherit
from NControlView, by providing direct access
to the rendered class, in case it's different
than NControlView, without having to cast it manually.
